### PR TITLE
New parameter to customize the CSV field separator

### DIFF
--- a/woo-product-importer-ajax.php
+++ b/woo-product-importer-ajax.php
@@ -32,6 +32,7 @@
         'product_image_skip_duplicates' => maybe_unserialize(stripslashes($_POST['product_image_skip_duplicates'])),
         'post_meta_key' => maybe_unserialize(stripslashes($_POST['post_meta_key'])),
         'user_locale' => maybe_unserialize(stripslashes($_POST['user_locale'])),
+        'import_csv_separator' => maybe_unserialize(stripslashes($_POST['import_csv_separator'])),
     );
 
     if(isset($post_data['uploaded_file_path'])) {
@@ -46,7 +47,7 @@
         $import_data = array();
 
         if ( $handle !== FALSE ) {
-            while ( ( $line = fgetcsv($handle) ) !== FALSE ) {
+            while ( ( $line = fgetcsv($handle, 0, $post_data['import_csv_separator']) ) !== FALSE ) {
                 $import_data[] = $line;
             }
             fclose( $handle );

--- a/woo-product-importer-preview.php
+++ b/woo-product-importer-preview.php
@@ -70,7 +70,11 @@
         $import_data = array();
 
         if ( $handle !== FALSE ) {
-            while ( ( $line = fgetcsv($handle) ) !== FALSE ) {
+        	$field_sep = null;
+        	if(isset($_POST['import_csv_separator'])) {
+        		$field_sep = $_POST['import_csv_separator'];
+        	}
+            while ( ( $line = fgetcsv($handle, 0, $field_sep) ) !== FALSE ) {
                 $import_data[] = $line;
             }
             fclose( $handle );

--- a/woo-product-importer-upload.php
+++ b/woo-product-importer-upload.php
@@ -498,6 +498,11 @@
             <table class="form-table">
                 <tbody>
                     <tr>
+                        <th><?php _e( 'CSV field separator', 'woo-product-importer' ); ?></th>
+                        <td>
+                        <input type="text" name="import_csv_separator" id="import_csv_separator" class="code" value=";" maxlength="1"></td>
+                    </tr>
+                    <tr>
                         <th><?php _e( 'Path to Your <strong>uploads</strong> Folder', 'woo-product-importer' ); ?></th>
                         <td><?php
                             $upload_dir = wp_upload_dir();


### PR DESCRIPTION
Hi,
I've added a new parameter to customize the field separator used to split CSV
lines (eg. ';' instead of ',') for one of my projects. Would be great to have this feature in future releases.
Continue your great work on this plugin, I think it could become something very very interesting!
Regards
