### PR TITLE
Change category hierarchy separator

### DIFF
--- a/woo-product-importer-ajax.php
+++ b/woo-product-importer-ajax.php
@@ -282,7 +282,7 @@
                         $term_paths = explode('|', $col);
                         foreach($term_paths as $term_path) {
 
-                            $term_names = explode('/', $term_path);
+                            $term_names = explode('>', $term_path);
                             $term_ids = array();
 
                             for($depth = 0; $depth < count($term_names); $depth++) {


### PR DESCRIPTION
I changed the category hierarchy separator to the > sign, because it is
less likely to appear in category names. For example if I have a
category with the name 50 liter/minute, it would make two categories, a
"50 liter" and a "minute" category.
