### PR TITLE
Undefined method WooCommerce::get_attribute_taxonomies

### DIFF
--- a/woo-product-importer-ajax.php
+++ b/woo-product-importer-ajax.php
@@ -82,7 +82,7 @@
         $inserted_rows = array();
 
         // lookup existing product attributes
-        $attribute_taxonomies = $woocommerce->get_attribute_taxonomies(); 
+        $attribute_taxonomies = wc_get_attribute_taxonomies();
         if (! is_array($attribute_taxonomies)) $attribute_taxonomies = array();
 
         //this is where the fun begins


### PR DESCRIPTION
Issue [#106](https://github.com/dgrundel/woo-product-importer/issues/106) fix.
